### PR TITLE
Update package dependencies across multiple projects

### DIFF
--- a/start/Catalog.Data.Manager/Catalog.Data.Manager.csproj
+++ b/start/Catalog.Data.Manager/Catalog.Data.Manager.csproj
@@ -13,8 +13,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.1">
+    <PackageReference Include="Aspire.Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.2.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.8">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/start/Catalog.Data/Catalog.Data.csproj
+++ b/start/Catalog.Data/Catalog.Data.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.1" />
+    <PackageReference Include="Aspire.Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.2.0" />
   </ItemGroup>
 
 </Project>

--- a/start/WebApp/WebApp.csproj
+++ b/start/WebApp/WebApp.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery.Yarp" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery.Yarp" Version="8.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/start/eShop.AppHost/eShop.AppHost.csproj
+++ b/start/eShop.AppHost/eShop.AppHost.csproj
@@ -1,23 +1,23 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
-    <Nullable>enable</Nullable>
-    <IsAspireHost>true</IsAspireHost>
-    <IsPackable>false</IsPackable>
-    <ImplicitUsings>enable</ImplicitUsings>
-  </PropertyGroup>
+	<PropertyGroup>
+		<OutputType>Exe</OutputType>
+		<TargetFramework>net8.0</TargetFramework>
+		<Nullable>enable</Nullable>
+		<IsAspireHost>true</IsAspireHost>
+		<IsPackable>false</IsPackable>
+		<ImplicitUsings>enable</ImplicitUsings>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.AppHost" Version="8.0.1" />
-    <PackageReference Include="Aspire.Hosting.PostgreSQL" Version="8.0.1" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Aspire.Hosting.AppHost"  Version="8.2.0" />
+		<PackageReference Include="Aspire.Hosting.PostgreSQL"  Version="8.2.0" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\Catalog.API\Catalog.API.csproj" />
-    <ProjectReference Include="..\Catalog.Data.Manager\Catalog.Data.Manager.csproj" />
-    <ProjectReference Include="..\WebApp\WebApp.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\Catalog.API\Catalog.API.csproj" />
+		<ProjectReference Include="..\Catalog.Data.Manager\Catalog.Data.Manager.csproj" />
+		<ProjectReference Include="..\WebApp\WebApp.csproj" />
+	</ItemGroup>
 
 </Project>

--- a/start/eShop.ServiceDefaults/eShop.ServiceDefaults.csproj
+++ b/start/eShop.ServiceDefaults/eShop.ServiceDefaults.csproj
@@ -13,15 +13,15 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="8.1.0" />
-    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="8.0.1" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.8.1" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.8.1" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.8.1" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="8.9.1" />
+    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="8.2.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.7.3" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.9.0" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.9.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.9.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="1.8.0-beta.1" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.8.1" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.8.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.9.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.9.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Updated various package dependencies to their latest versions:
- `Aspire.Npgsql.EntityFrameworkCore.PostgreSQL` to `8.2.0` in `Catalog.Data.Manager.csproj` and `Catalog.Data.csproj`.
- `Microsoft.EntityFrameworkCore.Tools` to `8.0.8` in `Catalog.Data.Manager.csproj`.
- `Microsoft.Extensions.ServiceDiscovery.Yarp` to `8.2.0` in `WebApp.csproj`.
- `Aspire.Hosting.AppHost` and `Aspire.Hosting.PostgreSQL` to `8.2.0` in `eShop.AppHost.csproj`.
- `Microsoft.AspNetCore.OpenApi` to `8.0.8`, `Microsoft.Extensions.Http.Resilience` to `8.9.1`, `Microsoft.Extensions.ServiceDiscovery` to `8.2.0`, `Swashbuckle.AspNetCore` to `6.7.3`, and various `OpenTelemetry` packages to `1.9.0` in `eShop.ServiceDefaults.csproj`.

Additionally, improved formatting in `eShop.AppHost.csproj` for better readability.